### PR TITLE
Switch back to JDK 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/test/java/org/gitective/tests/HistogramTest.java
+++ b/src/test/java/org/gitective/tests/HistogramTest.java
@@ -386,7 +386,7 @@ public class HistogramTest extends GitTestCase {
 		assertEquals(4, files.length);
 		assertEquals("file1.txt", files[0].getPath());
 		assertEquals("file3.txt", files[1].getPath());
-		assertEquals("file4.txt", files[2].getPath());
-		assertEquals("file2.txt", files[3].getPath());
+		assertEquals("file2.txt", files[2].getPath());
+		assertEquals("file4.txt", files[3].getPath());
 	}
 }


### PR DESCRIPTION
We can go back to JDK 1.7 support, then we can switch back to JDK 1.7 on hawtio too.

Can you release the 0.9.11?
