### PR TITLE
Upgrade Jgit to version 4.2.0.201601211800-r

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>4.1.1.201511131810-r</version>
+			<version>4.2.0.201601211800-r</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
Upgrade to latest Jgit.

This way we can release a new version of gitective and upgrade on fabric8 too.

Andrea
