### PR TITLE
Fix NPE when finding commits in repos without any

### DIFF
--- a/src/main/java/org/gitective/core/CommitUtils.java
+++ b/src/main/java/org/gitective/core/CommitUtils.java
@@ -67,7 +67,11 @@ public abstract class CommitUtils {
 			throw new IllegalArgumentException(
 					Assert.formatNotEmpty("Revision"));
 
-		return parse(repository, resolve(repository, revision));
+		ObjectId commitId = resolve(repository, revision);
+		if (commitId == null) {
+			return null;
+		}
+		return parse(repository, commitId);
 	}
 
 	/**

--- a/src/test/java/org/gitective/tests/CommitUtilsTest.java
+++ b/src/test/java/org/gitective/tests/CommitUtilsTest.java
@@ -145,6 +145,16 @@ public class CommitUtilsTest extends GitTestCase {
 	public void getCommitWithEmptyRevision() throws Exception {
 		CommitUtils.getCommit(new FileRepository(testRepo), "");
 	}
+	
+	/**
+	 * Get commit with non-existant revision 
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void getCommitWithNonExistantRevision() throws Exception {
+		assertEquals(null, CommitUtils.getCommit(new FileRepository(testRepo), "revision"));
+	}
 
 	/**
 	 * Get base with null repository parameter


### PR DESCRIPTION
As the issue tracker is disabled, I've created this pull request to show the issue and suggest a fix strategy.

When trying to use CommitFinder.getRevision() to find a commit in a repository that has been initialized but that has no commit yet, a NullPointerException is thrown.

My suggested fix is to detect when a revision couldn't be resolved (JGit returns null) and, instead of trying to parse the commitId, return null. This is an API change in that CommitFinder is no longer guaranteed to return something or throw an Exception.

An alternative strategy would be to throw an exception.

I have not checked whether this change breaks something somewhere else but have included a test case.

Signed-off-by: Johannes Dorn <johannes.dorn@codetrails.com>